### PR TITLE
Update nix dependenct to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ half-duplex SPI access, and full-duplex SPI access.
 [dependencies]
 libc = "^0.2.2"
 bitflags = "^0.3.3"
-nix = "^0.4.2"
+nix = "^0.5.0"


### PR DESCRIPTION
nix crate 0.4.2 is not compiling on rust 1.7 and 1.8. 

This updates nix dependency to 0.5.0 which allows to compile rust-spidev on current stable and nightly rust versions
