### PR TITLE
Expose the underlying file object.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,18 +206,34 @@ impl SpidevOptions {
 }
 
 impl Spidev {
+    /// Wrap an already opened [`File`] for use as an spidev
+    pub fn new(devfile: File) -> Self {
+        Self { devfile }
+    }
+
+
     /// Open the spidev device with the provided path
     ///
     /// Typically, the path will be something like `"/dev/spidev0.0"`
     /// where the first number if the bus and the second number
     /// is the chip select on that bus for the device being targeted.
     pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Spidev> {
-        let devfile = try!(OpenOptions::new()
-                               .read(true)
-                               .write(true)
-                               .create(false)
-                               .open(path));
-        Ok(Spidev { devfile: devfile })
+        let devfile = OpenOptions::new()
+                          .read(true)
+                          .write(true)
+                          .create(false)
+                          .open(path)?;
+        Ok(Self::new(devfile))
+    }
+
+    /// Get a reference to the underlying [`File`] object
+    pub fn inner(&self) -> &File {
+        &self.devfile
+    }
+
+    /// Consume the object and get the underlying [`File`] object
+    pub fn into_inner(self) -> File {
+        self.devfile
     }
 
     /// Write the provided configuration to this device


### PR DESCRIPTION
This PR adds the ability to use an already opened `File` object to create a new `Spidev`. Additionally, it adds read-only `inner()` and consuming `into_inner()` to access the underlying `File` object.

My primary reason for wanting this is that it allows to call `flock()` before using the spidev. That's something I want to do to avoid multiple processes controlling the same device.

And of course, if you can wrap an open `File`, it also makes sense to be able to access and retrieve it again.