### PR TITLE
Update documentation link in Cargo.toml to match README.md

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-embedded/rust-spidev"
 homepage = "https://github.com/rust-embedded/rust-spidev"
-documentation = "http://posborne.github.io/rust-spidev"
+documentation = "https://docs.rs/spidev"
 description = """
 Provides access to the Linux spidev interface.  This
 interface allows for configuration of the spidev device,


### PR DESCRIPTION
The doc link in README.md was updated to point to docs.rs in 02ebfc084afd4de8dd1faf768183f9913b4b6fe9, but the link in Cargo.toml still points to the old site. This PR updates Cargo.toml to match.

(I got confused following the docs link on crates.io, since the example code on the old site no longer builds :stuck_out_tongue:)