### PR TITLE
add README.md to Cargo.toml in order for crates.io to have a nice README preview

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.4.0"
 authors = ["Paul Osborne <osbpau@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
+readme = "README.md"
 repository = "https://github.com/rust-embedded/rust-spidev"
 homepage = "https://github.com/rust-embedded/rust-spidev"
 documentation = "https://docs.rs/spidev"


### PR DESCRIPTION
Currently the crates.io page only shows the description from Cargo.toml, see: https://crates.io/crates/spidev 

If you add `readme = "README.md"` it will show the README including the code example. This will attract more users to use this crate.