### PR TITLE
Prep release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Spidev Crate Changelog
 
+## 0.4.1 / 2021-02-21
+
+[Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.4.0...0.4.1)
+
+- Support Rust 2018 edition
+- Minimum supported rust version is now 1.31.0
+
 ## 0.4.0 / 2019-05-29
 
 [Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.3.0...0.4.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "spidev"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Paul Osborne <osbpau@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
It's been a couple of years since the last version bump, and #25 won't show up on crates.io until a new version is released.