### PR TITLE
Remove legacy code features / improve code quality to fit latest Rust standard

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,6 @@
 // option.  This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![crate_type = "lib"]
-#![crate_name = "spidev"]
-
 //! # Spidev
 //!
 //! The `spidev` crate provides access to Linux spidev devices
@@ -68,15 +65,10 @@
 //! }
 //! ```
 
-extern crate libc;
-#[macro_use]
-extern crate nix;
-#[macro_use]
-extern crate bitflags;
-
 pub mod spidevioctl;
 pub use crate::spidevioctl::SpidevTransfer;
 
+use bitflags::bitflags;
 use std::io;
 use std::io::prelude::*;
 use std::fs::{File, OpenOptions};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,11 +69,11 @@ pub mod spidevioctl;
 pub use crate::spidevioctl::SpidevTransfer;
 
 use bitflags::bitflags;
+use std::fs::{File, OpenOptions};
 use std::io;
 use std::io::prelude::*;
-use std::fs::{File, OpenOptions};
-use std::path::Path;
 use std::os::unix::prelude::*;
+use std::path::Path;
 
 // Constants extracted from linux/spi/spidev.h
 bitflags! {
@@ -203,7 +203,6 @@ impl Spidev {
         Self { devfile }
     }
 
-
     /// Open the spidev device with the provided path
     ///
     /// Typically, the path will be something like `"/dev/spidev0.0"`
@@ -211,10 +210,10 @@ impl Spidev {
     /// is the chip select on that bus for the device being targeted.
     pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Spidev> {
         let devfile = OpenOptions::new()
-                          .read(true)
-                          .write(true)
-                          .create(false)
-                          .open(path)?;
+            .read(true)
+            .write(true)
+            .create(false)
+            .open(path)?;
         Ok(Self::new(devfile))
     }
 
@@ -282,16 +281,16 @@ impl Write for Spidev {
 
 #[cfg(test)]
 mod test {
-    use super::{SpidevOptions, SpiModeFlags};
+    use super::{SpiModeFlags, SpidevOptions};
 
     #[test]
     fn test_spidev_options_all() {
         let options = SpidevOptions::new()
-                          .bits_per_word(8)
-                          .max_speed_hz(20_000)
-                          .lsb_first(false)
-                          .mode(SpiModeFlags::SPI_MODE_0)
-                          .build();
+            .bits_per_word(8)
+            .max_speed_hz(20_000)
+            .lsb_first(false)
+            .mode(SpiModeFlags::SPI_MODE_0)
+            .build();
         assert_eq!(options.bits_per_word, Some(8));
         assert_eq!(options.max_speed_hz, Some(20_000));
         assert_eq!(options.lsb_first, Some(false));

--- a/src/spidevioctl.rs
+++ b/src/spidevioctl.rs
@@ -6,9 +6,8 @@
 // option.  This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(dead_code)]
-
-use nix;
+// macros import
+use nix::{ioctl_read, ioctl_write_ptr, ioctl_write_buf};
 use std::io;
 use std::marker::PhantomData;
 use std::os::unix::prelude::*;
@@ -113,7 +112,7 @@ impl<'a, 'b> spi_ioc_transfer<'a, 'b> {
 }
 
 mod ioctl {
-    use super::spi_ioc_transfer;
+    use super::*;
 
     const SPI_IOC_MAGIC: u8 = 'k' as u8;
     const SPI_IOC_NR_TRANSFER: u8 = 0;


### PR DESCRIPTION
You recently pushed out version 0.4.1 which uses Rust edition 2018 officially. Anyhow, I found a few legacy code features and wanted to improve the code quality to fit latest Rust standard. My PR consists of two commits:

1. improve code quality
2. latest rustfmt (stable 1.50)

This PR compiles with Rust 1.31, the minimum Rust version this crate officially supports.