### PR TITLE
Allow Nix 0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.5.0...HEAD)
 
+- Updated nix to allow both version `0.22` or `0.23`.
+
 ## 0.5.0 / 2021-09-21
 
 [Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.4.1...0.5.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ half-duplex SPI access, and full-duplex SPI access.
 [dependencies]
 libc = "0.2"
 bitflags = "1.3"
-nix = "0.22"
+nix = ">= 0.22, < 0.24"


### PR DESCRIPTION
This crate compiles fine with nix 0.23 too. This change allows both nix 0.22 and 0.23 as dependency.