### PR TITLE
Implement AsRawFd for Spidev

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,6 +277,12 @@ impl Write for Spidev {
     }
 }
 
+impl AsRawFd for Spidev {
+    fn as_raw_fd(&self) -> RawFd {
+        self.devfile.as_raw_fd()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::{SpiModeFlags, SpidevOptions};


### PR DESCRIPTION
Implement `AsRawFd` for `Spidev` to allow access to the underlying file descriptor. This enables usage in async code.