### PR TITLE
chore: update dependencies and move to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ half-duplex SPI access, and full-duplex SPI access.
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.3"
-nix = "0.23"
+bitflags = "2.3"
+nix = "0.26"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ use std::path::Path;
 
 // Constants extracted from linux/spi/spidev.h
 bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct SpiModeFlags: u32 {
         /// Clock Phase
         const SPI_CPHA = 0x01;
@@ -97,9 +98,9 @@ bitflags! {
 
         // Common Configurations
         const SPI_MODE_0 = 0x00;
-        const SPI_MODE_1 = Self::SPI_CPHA.bits;
-        const SPI_MODE_2 = Self::SPI_CPOL.bits;
-        const SPI_MODE_3 = (Self::SPI_CPOL.bits | Self::SPI_CPHA.bits);
+        const SPI_MODE_1 = Self::SPI_CPHA.bits();
+        const SPI_MODE_2 = Self::SPI_CPOL.bits();
+        const SPI_MODE_3 = (Self::SPI_CPOL.bits() | Self::SPI_CPHA.bits());
 
         // == Only Supported with 32-bits ==
 

--- a/src/spidevioctl.rs
+++ b/src/spidevioctl.rs
@@ -184,10 +184,10 @@ pub fn set_mode(fd: RawFd, mode: SpiModeFlags) -> io::Result<()> {
     // the 8-bit mask are used.  This is because WR_MODE32 was not
     // added until later kernels.  This provides a reasonable story
     // for forwards and backwards compatibility
-    if (mode.bits & 0xFFFFFF00) != 0 {
-        from_nix_result(unsafe { ioctl::set_mode32(fd, &mode.bits) })?;
+    if (mode.bits() & 0xFFFFFF00) != 0 {
+        from_nix_result(unsafe { ioctl::set_mode32(fd, &mode.bits()) })?;
     } else {
-        let bits: u8 = mode.bits as u8;
+        let bits: u8 = mode.bits() as u8;
         from_nix_result(unsafe { ioctl::set_mode(fd, &bits) })?;
     }
     Ok(())


### PR DESCRIPTION
This repo hasn't received any update recently so I though it's a good time to update some dependencies and move to 2021 edition.