### PR TITLE
Support delay transactions + 0.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Not yet released
 
-[Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.5.1...HEAD)
+[Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.5.2...HEAD)
+
+
+## 0.5.2 / 2023-08-02
+
+[Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.5.1...0.5.2)
 
 - Added support for delay transactions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.5.1...HEAD)
 
+- Added support for delay transactions.
+
 ## 0.5.1 / 2021-11-22
 
 [Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.5.0...0.5.1)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "spidev"
-version = "0.5.1"
+version = "0.5.2"
 authors = [
     "Paul Osborne <osbpau@gmail.com>",
     "The Embedded Linux Team <embedded-linux@teams.rust-embedded.org>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 
 name = "spidev"
 version = "0.5.1"
-authors = ["Paul Osborne <osbpau@gmail.com>"]
+authors = [
+    "Paul Osborne <osbpau@gmail.com>",
+    "The Embedded Linux Team <embedded-linux@teams.rust-embedded.org>"
+]
 edition = "2018"
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Paul Osborne
+Copyright (c) 2021-2023 The Rust Embedded Linux Team and contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +20,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 The Rust `spidev` seeks to provide full access to the Linux spidev
 device in Rust without the need to wrap any C code or directly make
 low-level system calls.  The documentation for the spidev interace can
-be found at https://www.kernel.org/doc/Documentation/spi/spidev.
+be found at <https://www.kernel.org/doc/Documentation/spi/spidev>.
 
 ## Example/API
 
@@ -91,7 +91,7 @@ raspberry pi or beaglebone black:
    can be done by doing `sudo apt-get install g++-arm-linux-gnueabihf`.
 3. Build or install rust for your target.  This is necessary in order
    to have libstd available for your target.  For arm-linux-gnueabihf,
-   you can find binaries at https://github.com/japaric/ruststrap.
+   you can find binaries at <https://github.com/japaric/ruststrap>.
    With this approach or building it yourself, you will need to copy
    the ${rust}/lib/rustlib/arm-unknown-linux-gnueabihf to your system
    rust library folder (it is namespaced by triple, so it shouldn't
@@ -112,8 +112,8 @@ linker = "arm-linux-gnueabihf-gcc"
 Licensed under either of
 
 - Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
-  http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+  <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/examples/spidev-bidir.rs
+++ b/examples/spidev-bidir.rs
@@ -21,12 +21,14 @@ fn main() {
     println!("===== Multi Transfer =========");
     let mut rx_buf1 = [0; 10];
     let tx_buf2 = [0x00, 0x01, 0x02, 0x03];
+    let delay_usecs = 10;
     let tx_buf3 = [0xff, 0xfe, 0xfd];
     let mut rx_buf3 = [0; 3];
     let result = {
         let mut transfers = vec![
             SpidevTransfer::read(&mut rx_buf1),
             SpidevTransfer::write(&tx_buf2),
+            SpidevTransfer::delay(delay_usecs),
             SpidevTransfer::read_write(&tx_buf3, &mut rx_buf3),
         ];
         spidev.transfer_multiple(&mut transfers)
@@ -35,6 +37,7 @@ fn main() {
         Ok(_) => {
             println!("Read {:?}", rx_buf1);
             println!("Wrote {:?}", tx_buf2);
+            println!("Delayed by {} microseconds", delay_usecs);
             println!("Wrote {:?} and read {:?}", tx_buf3, rx_buf3);
         }
         Err(err) => println!("{:?}", err),

--- a/examples/spidev-hello.rs
+++ b/examples/spidev-hello.rs
@@ -4,9 +4,9 @@ use std::io::prelude::*;
 
 fn main() {
     let mut spidev = Spidev::open("/dev/spidev0.0").unwrap();
-    spidev.write(&[0xAA, 0x00, 0x01, 0x02, 0x04]).unwrap();
+    let wrote = spidev.write(&[0xAA, 0x00, 0x01, 0x02, 0x04]).unwrap();
 
     let mut buf: [u8; 10] = [0; 10];
-    spidev.read(&mut buf).unwrap(); // read 10
-    println!("{:?}", buf);
+    let read = spidev.read(&mut buf).unwrap(); // read 10
+    println!("Wrote: {}, Read: {}, Data: {:?}", wrote, read, buf);
 }

--- a/src/spidevioctl.rs
+++ b/src/spidevioctl.rs
@@ -78,6 +78,7 @@ pub struct spi_ioc_transfer<'a, 'b> {
 }
 
 impl<'a, 'b> spi_ioc_transfer<'a, 'b> {
+    /// Create a read transfer
     pub fn read(buff: &'b mut [u8]) -> Self {
         spi_ioc_transfer {
             rx_buf: buff.as_ptr() as *const () as usize as u64,
@@ -86,6 +87,7 @@ impl<'a, 'b> spi_ioc_transfer<'a, 'b> {
         }
     }
 
+    /// Create a write transfer
     pub fn write(buff: &'a [u8]) -> Self {
         spi_ioc_transfer {
             tx_buf: buff.as_ptr() as *const () as usize as u64,
@@ -94,13 +96,23 @@ impl<'a, 'b> spi_ioc_transfer<'a, 'b> {
         }
     }
 
-    /// The `tx_buf` and `rx_buf` must be the same length.
+    /// Create a read/write transfer.
+    /// Note that the `tx_buf` and `rx_buf` must be the same length.
     pub fn read_write(tx_buf: &'a [u8], rx_buf: &'b mut [u8]) -> Self {
         assert_eq!(tx_buf.len(), rx_buf.len());
         spi_ioc_transfer {
             rx_buf: rx_buf.as_ptr() as *const () as usize as u64,
             tx_buf: tx_buf.as_ptr() as *const () as usize as u64,
             len: tx_buf.len() as u32,
+            ..Default::default()
+        }
+    }
+
+    /// Create a delay transfer of a number of microseconds
+    pub fn delay(microseconds: u16) -> Self {
+        spi_ioc_transfer {
+            delay_usecs: microseconds,
+            len: 0,
             ..Default::default()
         }
     }


### PR DESCRIPTION
I have added support for delay transactions and prepared a new release.

The next step would be to update `nix` and make a new breaking release.