### PR TITLE
Update dependencies + bump MRSV + 0.6.0 release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rust-embedded/embedded-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
 
 name: CI
 
+env:
+  RUSTFLAGS: '--deny warnings'
+
 jobs:
   ci-linux:
     name: CI
@@ -15,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # All published crates must build on stable.
-        rust: [stable, beta, 1.46.0]
+        rust: [stable, beta, 1.56.1]
 
         # The default target we're compiling on and for.
         TARGET: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl]
@@ -27,26 +30,13 @@ jobs:
             TARGET: x86_64-unknown-linux-gnu
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.TARGET }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target=${{ matrix.TARGET }}
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=${{ matrix.TARGET }}
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target=${{ matrix.TARGET }}
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=${{ matrix.TARGET }} --examples
+          target: ${{ matrix.target }}
+
+      - run: cargo check --target=${{ matrix.TARGET }}
+      - run: cargo build --target=${{ matrix.TARGET }}
+      - run: cargo test --target=${{ matrix.TARGET }}
+      - run: cargo build --target=${{ matrix.TARGET }} --examples

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -10,13 +10,9 @@ jobs:
   clippy_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: 1.55.0
-          override: true
+          toolchain: 1.71.0
           components: clippy
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo clippy

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -12,14 +12,9 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          toolchain: 1.71.0
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 [Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.5.2...HEAD)
 
+- Nix updated to 0.26
+- bitflags updated to 2.3
+- Minimum Supported Rust Version is now 1.56.1
 
 ## 0.5.2 / 2023-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Not yet released
 
-[Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.5.2...HEAD)
+[Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.6.0...HEAD)
+
+## 0.6.0 / 2023-08-03
+
+[Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.5.2...0.6.0)
 
 - Nix updated to 0.26
 - bitflags updated to 2.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ half-duplex SPI access, and full-duplex SPI access.
 [dependencies]
 libc = "0.2"
 bitflags = "2.3"
-nix = "0.26"
+nix = "0.26.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ half-duplex SPI access, and full-duplex SPI access.
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.3"
-nix = "0.23"
+bitflags = "2.3"
+nix = "0.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "spidev"
-version = "0.5.2"
+version = "0.6.0"
 authors = [
     "Paul Osborne <osbpau@gmail.com>",
     "The Embedded Linux Team <embedded-linux@teams.rust-embedded.org>"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://github.com/rust-embedded/rust-spidev/workflows/CI/badge.svg)](https://github.com/rust-embedded/rust-spidev/actions)
 [![Version](https://img.shields.io/crates/v/spidev.svg)](https://crates.io/crates/spidev)
 [![License](https://img.shields.io/crates/l/spidev.svg)](https://github.com/rust-embedded/rust-spidev/blob/master/README.md#license)
+![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.56.1+-blue.svg)
 
 [Documentation](https://docs.rs/spidev)
 
@@ -76,7 +77,7 @@ The following features are implemented and planned for the library:
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.46 and up.  It *might*
+This crate is guaranteed to compile on stable Rust 1.56.1 and up.  It *might*
 compile with older versions but that may change in any new patch release.
 
 ## Cross Compiling

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ use std::path::Path;
 
 // Constants extracted from linux/spi/spidev.h
 bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct SpiModeFlags: u32 {
         /// Clock Phase
         const SPI_CPHA = 0x01;
@@ -97,9 +98,9 @@ bitflags! {
 
         // Common Configurations
         const SPI_MODE_0 = 0x00;
-        const SPI_MODE_1 = Self::SPI_CPHA.bits;
-        const SPI_MODE_2 = Self::SPI_CPOL.bits;
-        const SPI_MODE_3 = (Self::SPI_CPOL.bits | Self::SPI_CPHA.bits);
+        const SPI_MODE_1 = Self::SPI_CPHA.bits();
+        const SPI_MODE_2 = Self::SPI_CPOL.bits();
+        const SPI_MODE_3 = (Self::SPI_CPOL.bits() | Self::SPI_CPHA.bits());
 
         // == Only Supported with 32-bits ==
 

--- a/src/spidevioctl.rs
+++ b/src/spidevioctl.rs
@@ -196,10 +196,10 @@ pub fn set_mode(fd: RawFd, mode: SpiModeFlags) -> io::Result<()> {
     // the 8-bit mask are used.  This is because WR_MODE32 was not
     // added until later kernels.  This provides a reasonable story
     // for forwards and backwards compatibility
-    if (mode.bits & 0xFFFFFF00) != 0 {
-        from_nix_result(unsafe { ioctl::set_mode32(fd, &mode.bits) })?;
+    if (mode.bits() & 0xFFFFFF00) != 0 {
+        from_nix_result(unsafe { ioctl::set_mode32(fd, &mode.bits()) })?;
     } else {
-        let bits: u8 = mode.bits as u8;
+        let bits: u8 = mode.bits() as u8;
         from_nix_result(unsafe { ioctl::set_mode(fd, &bits) })?;
     }
     Ok(())


### PR DESCRIPTION
Superseeds #38. Sorry I only saw that now.

TODO: update branch protection rules with the new MRSV.