### PR TITLE
Add function to query current SPI device configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.6.0...HEAD)
 
+- Added support for querying the configuration of a SPI device.
+
 ## 0.6.0 / 2023-08-03
 
 [Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.5.2...0.6.0)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,8 +253,9 @@ impl Spidev {
         let speed = spidevioctl::get_max_speed_hz(fd)?;
         let lsb_first = (spidevioctl::get_lsb_first(fd)?) != 0;
 
-        // Try to get the mode as 32-bit (RD_MODE32). Older kernels may return ENOTTY
-        // indicating 32-bit is not supported. In that case we retry in 8-bit mode.
+        // Try to get the mode as 32-bit (`RD_MODE32`). Older kernels may return
+        // `ENOTTY` indicating 32-bit is not supported. In that case we retry in
+        // 8-bit mode.
         let mode_bits = spidevioctl::get_mode_u32(fd).or_else(|err| {
             if err.raw_os_error() == Some(libc::ENOTTY) {
                 spidevioctl::get_mode(fd).map(|value| value as u32)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,6 +245,36 @@ impl Spidev {
         Ok(())
     }
 
+    /// Read the current configuration from this device
+    pub fn query_configuration(&self) -> io::Result<SpidevOptions> {
+        let fd = self.devfile.as_raw_fd();
+
+        let bpw = spidevioctl::get_bits_per_word(fd)?;
+        let speed = spidevioctl::get_max_speed_hz(fd)?;
+        let lsb_first = (spidevioctl::get_lsb_first(fd)?) != 0;
+
+        // Try to get the mode as 32-bit (RD_MODE32). Older kernels may return ENOTTY
+        // indicating 32-bit is not supported. In that case we retry in 8-bit mode.
+        let mode_bits = spidevioctl::get_mode_u32(fd).or_else(|err| {
+            if let Some(libc::ENOTTY) = err.raw_os_error() {
+                spidevioctl::get_mode(fd).map(|value| value as u32)
+            } else {
+                Err(err)
+            }
+        })?;
+
+        let mode = SpiModeFlags::from_bits_retain(mode_bits);
+
+        let options = SpidevOptions::new()
+            .bits_per_word(bpw)
+            .max_speed_hz(speed)
+            .lsb_first(lsb_first)
+            .mode(mode)
+            .build();
+
+        Ok(options)
+    }
+
     /// Perform a single transfer
     pub fn transfer(&self, transfer: &mut SpidevTransfer) -> io::Result<()> {
         spidevioctl::transfer(self.devfile.as_raw_fd(), transfer)

--- a/src/spidevioctl.rs
+++ b/src/spidevioctl.rs
@@ -191,6 +191,12 @@ pub fn get_mode(fd: RawFd) -> io::Result<u8> {
     Ok(mode)
 }
 
+pub fn get_mode_u32(fd: RawFd) -> io::Result<u32> {
+    let mut mode: u32 = 0;
+    from_nix_result(unsafe { ioctl::get_mode_u32(fd, &mut mode) })?;
+    Ok(mode)
+}
+
 pub fn set_mode(fd: RawFd, mode: SpiModeFlags) -> io::Result<()> {
     // we will always use the 8-bit mode write unless bits not in
     // the 8-bit mask are used.  This is because WR_MODE32 was not


### PR DESCRIPTION
This introduces a function called "query_configuration" which reads the current config and returns a "SpidevOptions" object.

For the mode it tries 32 bit first and if that fails because the kernel is to old, it retries with 8 bit.