### PR TITLE
Release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## Not yet released
 
-[Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.6.0...HEAD)
+[Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.6.1...HEAD)
+
+## 0.6.1 / 2025-10-23
+
+[Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.6.0...0.6.1)
+
+- Backport `read_write_in_place` from [#49](https://github.com/rust-embedded/rust-spidev/pull/49)
+  for fixing
+  [linux-embedded-hal/#120](https://github.com/rust-embedded/linux-embedded-hal/issues/120)
+  with a patch release
+
 
 ## 0.6.0 / 2023-08-03
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "spidev"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
     "Paul Osborne <osbpau@gmail.com>",
     "The Embedded Linux Team <embedded-linux@teams.rust-embedded.org>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "spidev"
-version = "0.6.1"
+version = "0.6.2-alpha.0"
 authors = [
     "Paul Osborne <osbpau@gmail.com>",
     "The Embedded Linux Team <embedded-linux@teams.rust-embedded.org>"

--- a/src/spidevioctl.rs
+++ b/src/spidevioctl.rs
@@ -108,6 +108,19 @@ impl<'a, 'b> spi_ioc_transfer<'a, 'b> {
         }
     }
 
+    /// Create a read/write transfer using the same buffer for reading
+    /// and writing (in-place transfer).
+    pub fn read_write_in_place(buf: &'a mut [u8]) -> Self {
+        // This is allowed according to a comment in the linux source tree:
+        // https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/include/linux/spi/spi.h?id=211ddde0823f1442e4ad052a2f30f050145ccada#n1073
+        spi_ioc_transfer {
+            rx_buf: buf.as_ptr() as *const () as usize as u64,
+            tx_buf: buf.as_ptr() as *const () as usize as u64,
+            len: buf.len() as u32,
+            ..Default::default()
+        }
+    }
+
     /// Create a delay transfer of a number of microseconds
     pub fn delay(microseconds: u16) -> Self {
         spi_ioc_transfer {

--- a/src/spidevioctl.rs
+++ b/src/spidevioctl.rs
@@ -112,7 +112,7 @@ impl<'a, 'b> spi_ioc_transfer<'a, 'b> {
     /// and writing (in-place transfer).
     pub fn read_write_in_place(buf: &'a mut [u8]) -> Self {
         // This is allowed according to a comment in the linux source tree:
-        // https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/include/linux/spi/spi.h?id=211ddde0823f1442e4ad052a2f30f050145ccada#n1073
+        // https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/Documentation/spi/spidev.rst?id=211ddde0823f1442e4ad052a2f30f050145ccada#n191
         spi_ioc_transfer {
             rx_buf: buf.as_ptr() as *const () as usize as u64,
             tx_buf: buf.as_ptr() as *const () as usize as u64,


### PR DESCRIPTION
The linux-embedded-hal exposes spidev and in order to fix https://github.com/rust-embedded/linux-embedded-hal/issues/120, we need a patch release for 0.6. I already created the branch [maintenance-0.6](https://github.com/rust-embedded/rust-spidev/tree/maintenance-0.6) and this PR backports #49 onto 0.6 and prepares release 0.6.1.