### PR TITLE
Work around CI failure with old rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
 
+      - if: ${{ matrix.rust=='1.56.1' }}
+        run: cargo update --precise 0.2.163 --package libc
       - run: cargo check --target=${{ matrix.TARGET }}
       - run: cargo build --target=${{ matrix.TARGET }}
       - run: cargo test --target=${{ matrix.TARGET }}


### PR DESCRIPTION
The libc crate broke compatibility with our MSRV without a semver version bump. Force using a sufficiently old libc version in our CI.