### PR TITLE
Release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Not yet released
 
-[Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.7.0...HEAD)
+[Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.7.1...HEAD)
+
+## 0.7.1 / 2025-10-27
+
+[Full Changelog](https://github.com/rust-embedded/rust-spidev/compare/0.7.0...0.7.1)
 
 - Implement a `read_write_in_place` method for in-place transfers.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "spidev"
-version = "0.7.1"
+version = "0.7.2-alpha.0"
 authors = [
     "Paul Osborne <osbpau@gmail.com>",
     "The Embedded Linux Team <embedded-linux@teams.rust-embedded.org>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "spidev"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "Paul Osborne <osbpau@gmail.com>",
     "The Embedded Linux Team <embedded-linux@teams.rust-embedded.org>"


### PR DESCRIPTION
We've cut release 0.6.1 with #50 and should also provide a patch release for 0.7. This PR does the following:

* Updates the crate version to 0.7.1 and update the changelog
* Additionally sets the crate version to 0.7.2-alpha.0 for having distinguishable version information for the upcoming development cycle

I case of doubt, please see the individual commits. Please rebase and don't squash this PR.